### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/django_pony_forms/pony_forms.py
+++ b/django_pony_forms/pony_forms.py
@@ -131,7 +131,7 @@ class FormContext(object):
         for bound_field in six.itervalues(self.hidden_field_dict):
             if bound_field.errors:
                 top_errors.extend([
-                    u'(Hidden field %s) %s' % (bound_field.name, force_text(e)) for e in bound_field.errors
+                    u'(Hidden field {0!s}) {1!s}'.format(bound_field.name, force_text(e)) for e in bound_field.errors
                 ])
 
         return top_errors

--- a/testproject/testapp/forms.py
+++ b/testproject/testapp/forms.py
@@ -12,7 +12,7 @@ class ExampleTextarea(forms.Textarea):
 
     def render(self, name, value, attrs, label):
         return (
-            mark_safe('<label>%s</label>' % six.text_type(label)) +
+            mark_safe('<label>{0!s}</label>'.format(six.text_type(label))) +
             super(ExampleTextarea, self).render(name, value, attrs)
         )
 

--- a/testproject/testapp/tests.py
+++ b/testproject/testapp/tests.py
@@ -17,7 +17,7 @@ class PonyFormTest(unittest.TestCase):
         form = ExampleForm()
 
         # Wrap html in 'div' so pyquery can parse it
-        html = u"<div>%s</div>" % six.text_type(form)
+        html = u"<div>{0!s}</div>".format(six.text_type(form))
         d = pq(html)
 
         # Check hidden field
@@ -57,7 +57,7 @@ class PonyFormTest(unittest.TestCase):
         # 2. Post form
         form = ExampleForm(dict())
 
-        html = u"<div>%s</div>" % six.text_type(form)
+        html = u"<div>{0!s}</div>".format(six.text_type(form))
         d = pq(html)
 
         errorlist = d('div.alert')
@@ -136,7 +136,7 @@ class PonyFormTest(unittest.TestCase):
         form.fields['name'].label = ''
 
         # 1. Get html
-        html = u"<div>%s</div>" % six.text_type(form)
+        html = u"<div>{0!s}</div>".format(six.text_type(form))
         d = pq(html)
 
         self.assertEqual(len(d('.row-name label')), 0)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:mbraak:django_pony_forms?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:mbraak:django_pony_forms?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)